### PR TITLE
Fixed compatability with jars built with J16 & added signature stripping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,13 +43,13 @@
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
-            <version>7.1</version>
+            <version>9.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-commons</artifactId>
-            <version>7.1</version>
+            <version>9.2</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Updated ASM to support jars that are compiled with Java 16 & added signature stripping to avoid output files from becoming unusable due to the jvm being unable to verify it's signatures.